### PR TITLE
Fix utf8 encoding bug in xml signature input canonicalization

### DIFF
--- a/SAML2/XML.hs
+++ b/SAML2/XML.hs
@@ -28,7 +28,7 @@ module SAML2.XML
 
 import qualified Text.XML.HXT.DOM.ShowXml
 import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString.Lazy.Char8 as BSLC
+import qualified Data.ByteString.Lazy.UTF8 as BSLU
 import Data.Default (Default(..))
 import qualified Data.Invertible as Inv
 import Data.Maybe (listToMaybe)
@@ -146,7 +146,7 @@ xmlToDocBroken = listToMaybe . HXT.runLA
   HXT.>>> HXT.removeWhiteSpace
   HXT.>>> HXT.neg HXT.isXmlPi
   HXT.>>> HXT.propagateNamespaces)
-  . BSLC.unpack -- XXX encoding?
+  . BSLU.toString
 
 docToSAML :: XP.XmlPickler a => HXT.XmlTree -> Either String a
 docToSAML = XP.unpickleDoc' XP.xpickle

--- a/SAML2/XML.hs
+++ b/SAML2/XML.hs
@@ -138,7 +138,8 @@ xmlToDocE = fix . xmlToDocBroken
     fix (Just good) =
       Right good
 
--- | this is broken and returns xml trees containing parse errors on occasion.
+-- | Take a UTF-8 encoded bytestring and return an xml tree.  This is broken and returns xml
+-- trees containing parse errors on occasion; call 'xmlToDocE' instead.
 xmlToDocBroken :: BSL.ByteString -> Maybe HXT.XmlTree
 xmlToDocBroken = listToMaybe . HXT.runLA
   (HXT.xreadDoc

--- a/SAML2/XML/Signature.hs
+++ b/SAML2/XML/Signature.hs
@@ -278,6 +278,7 @@ verifySignature pks xid doc = runExceptT $ do
           Right v -> pure v
 
   -- validate the hashes
+  -- (this only works if reference list contains xid and nothing else.)
   referenceChecks :: NonEmpty.NonEmpty (Either String String)
     <- failWith (SignatureVerifyReferenceError . (show (signedInfoReference signedInfoTyped) <>))
       . capture' "verifyReference"

--- a/SAML2/XML/Types.hs
+++ b/SAML2/XML/Types.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE QuasiQuotes #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
 module SAML2.XML.Types where
 
 import Data.List.NonEmpty (NonEmpty(..))

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ dependencies:
   - string-conversions
   - template-haskell
   - time
+  - utf8-string
   - x509
   - zlib
 


### PR DESCRIPTION
Failing test case in 39a462f explains the problem.