### PR TITLE
Add cabal file

### DIFF
--- a/hsaml2.cabal
+++ b/hsaml2.cabal
@@ -1,0 +1,148 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.32.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 2acfb238f4a4776225446a00bae4dbea0ef09d1ee110bf475af3cbce70e0aeb5
+
+name:           hsaml2
+version:        0.1
+synopsis:       OASIS Security Assertion Markup Language (SAML) V2.0
+description:    Direct implementation of the SAML XML standard (https://www.oasis-open.org/standards#samlv2.0), along with some related dependencies.  This is currently partial, as the standard is quite extensive, but is sufficient to build a functioning SP and fully validate responses.  The module layout basically follows the standard definition documentation.  Its use still requires a fairly extensive understanding of SAML.
+category:       Security, Network, Web
+homepage:       https://github.com/dylex/hsaml2#readme
+bug-reports:    https://github.com/dylex/hsaml2/issues
+author:         Dylan Simon
+maintainer:     dylan@dylex.net
+copyright:      2016
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    test/XML/signature-example.xml
+    test/XML/encryption-example.xml
+
+source-repository head
+  type: git
+  location: https://github.com/dylex/hsaml2
+
+library
+  exposed-modules:
+      SAML2
+      SAML2.Bindings
+      SAML2.Bindings.General
+      SAML2.Bindings.HTTPPOST
+      SAML2.Bindings.HTTPRedirect
+      SAML2.Bindings.Identifiers
+      SAML2.Bindings.Internal
+      SAML2.Core
+      SAML2.Core.Assertions
+      SAML2.Core.Datatypes
+      SAML2.Core.Identifiers
+      SAML2.Core.Namespaces
+      SAML2.Core.Protocols
+      SAML2.Core.Signature
+      SAML2.Core.Versioning
+      SAML2.Lens
+      SAML2.Metadata
+      SAML2.Metadata.Metadata
+      SAML2.Profiles
+      SAML2.Profiles.ConfirmationMethod
+      SAML2.XML
+      SAML2.XML.ASN1
+      SAML2.XML.Canonical
+      SAML2.XML.Encryption
+      SAML2.XML.LibXML2
+      SAML2.XML.Schema
+      SAML2.XML.Schema.Datatypes
+      SAML2.XML.Signature
+      SAML2.XML.Signature.Types
+      SAML2.XML.Types
+  other-modules:
+      Paths_hsaml2
+  hs-source-dirs:
+      ./.
+  ghc-options: -Wall
+  c-sources:
+      SAML2/XML/libxml2_stub.c
+  pkgconfig-depends:
+      libxml-2.0
+  build-depends:
+      asn1-encoding
+    , asn1-types >=0.2
+    , base >=4.8 && <5
+    , base64-bytestring
+    , bytestring
+    , cryptonite
+    , data-default
+    , http-types
+    , hxt
+    , hxt-charproperties
+    , hxt-unicode
+    , invertible
+    , invertible-hxt
+    , lens
+    , memory
+    , mtl
+    , network-uri
+    , process
+    , semigroups
+    , silently
+    , string-conversions
+    , template-haskell
+    , time
+    , utf8-string
+    , x509
+    , zlib
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Bindings.HTTPRedirect
+      Metadata.Metadata
+      XML
+      XML.Canonical
+      XML.Encryption
+      XML.Signature
+      Paths_hsaml2
+  hs-source-dirs:
+      test
+  ghc-options: -Wall
+  c-sources:
+      SAML2/XML/libxml2_stub.c
+  pkgconfig-depends:
+      libxml-2.0
+  build-depends:
+      HUnit
+    , asn1-encoding
+    , asn1-types >=0.2
+    , base >=4.8 && <5
+    , base64-bytestring
+    , bytestring
+    , cryptonite
+    , data-default
+    , hsaml2
+    , http-types
+    , hxt
+    , hxt-charproperties
+    , hxt-http
+    , hxt-unicode
+    , invertible
+    , invertible-hxt
+    , lens
+    , memory
+    , mtl
+    , network-uri
+    , process
+    , semigroups
+    , silently
+    , string-conversions
+    , template-haskell
+    , time
+    , utf8-string
+    , x509
+    , zlib
+  default-language: Haskell2010


### PR DESCRIPTION
Not having it here is problematic, as packages depending on it can't pin
the repository as the hash of the repository depends on the version of
hpack used which can vary from system to system.

Stack is actually changing this behaviour soon:
https://tech.fpcomplete.com/blog/storing-generated-cabal-files

We hit this bug here:
wireapp/wire-server#1027 (comment)
where now CI isn't reproducible because the cabal file generated on my
machine doesn't match the cabal file generated on CI